### PR TITLE
skip upper limit for range of current month

### DIFF
--- a/superset-frontend/src/filters/components/TimeSimplified/FilterLabel.tsx
+++ b/superset-frontend/src/filters/components/TimeSimplified/FilterLabel.tsx
@@ -107,7 +107,7 @@ const presets = [
   },
   {
     label: 'this month',
-    value: "DATETRUNC(DATETIME('today'), MONTH) : DATETIME('today')",
+    value: "DATETRUNC(DATETIME('today'), MONTH) : ",
   },
 ];
 


### PR DESCRIPTION
WHERE _date >= '2024-03-01 00:00:00.000000'
  AND _date < '2024-03-01 00:00:00.000000'

replaced with:
WHERE _date >= '2024-03-01 00:00:00.000000'